### PR TITLE
Modules that no longer supported.

### DIFF
--- a/en/docs/system-updates.md
+++ b/en/docs/system-updates.md
@@ -6,8 +6,13 @@
     * This change requires you to recompile your programs or rebuild the Python virtual environments.
 
 * The following tools will no longer be supported on 2023/03/31.
+  For modules that are no longer supported, please use container images or [previous ABCI Environment Modules](faq.md#q-how-to-use-previous-abci-environment-modules).
+  For more information, please refer to the [Modules removed and alternatives](tips/modules-removed-and-alternatives.md).
+    * Compilers：PGI
     * Development Tools：Lua
     * Deep Learning Frameworks：Caffe, Caffe2, Theano, Chainer
+    * MPI：OpenMPI
+    * Utilities：fuse-sshfs
     * Container Engine：Docker
 
 * The inode quota limit for groups area will be set.

--- a/ja/docs/system-updates.md
+++ b/ja/docs/system-updates.md
@@ -6,8 +6,13 @@
     * 本変更に伴い、プログラムの再コンパイルやPython仮想環境の再構築が必要になります。
 
 * 下記は2023年3月末日でサポートを終了します。
+  終了したモジュールについては、コンテナイメージの利用もしくは、[過去のABCI Environment Modules](faq.md#q-how-to-use-previous-abci-environment-modules)をご利用ください。
+  詳しくは、Tipsの[提供を終了したモジュールとその代替手段](tips/modules-removed-and-alternatives.md)を参照してください。
+    * Compilers：PGI
     * Development Tools：Lua
     * Deep Learning Frameworks：Caffe, Caffe2, Theano, Chainer
+    * MPI：OpenMPI
+    * Utilities：fuse-sshfs
     * コンテナエンジン：Docker
 
 * ABCIグループ領域のinode数上限値が設定されます。


### PR DESCRIPTION
来年度にサポート外とするモジュール(pgi、openmpi、fuse-sshfs)の追加と、サポート外のあとの利用について、システム更新予定に文章を追加しました。