### PR TITLE
Updated Environment Modules

### DIFF
--- a/en/docs/environment-modules.md
+++ b/en/docs/environment-modules.md
@@ -44,7 +44,7 @@ Currently Loaded Modulefiles:
 ### Display the configuration of modules
 
 ```
-[username@es1 ~]$ module show module show cuda/11.7/11.7.1
+[username@es1 ~]$ module show cuda/11.7/11.7.1
 -------------------------------------------------------------------
 /apps/modules/modulefiles/rocky8/gpgpu/cuda/11.7/11.7.1:
 

--- a/en/docs/environment-modules.md
+++ b/en/docs/environment-modules.md
@@ -30,59 +30,62 @@ The following is a list of sub-commands.
 ### Loading modules
 
 ```
-[username@g0001 ~]$ module load cuda/10.0/10.0.130.1 cudnn/7.6/7.6.5
+[username@es1 ~]$ module load cuda/11.7/11.7.1 cudnn/8.4/8.4.1
 ```
 
 ### List loaded modules
 
 ```
-[username@g0001 ~]$ module list
+[username@es1 ~]$ module list
 Currently Loaded Modulefiles:
-  1) cuda/10.0/10.0.130.1   2) cudnn/7.6/7.6.5
+ 1) cuda/11.7/11.7.1   2) cudnn/8.4/8.4.1
 ```
 
 ### Display the configuration of modules
 
 ```
-[username@g0001 ~]$ module show cuda/10.0/10.0.130.1
+[username@es1 ~]$ module show module show cuda/11.7/11.7.1
 -------------------------------------------------------------------
-/apps/modules/modulefiles/centos7/gpgpu/cuda/10.0/10.0.130.1:
+/apps/modules/modulefiles/rocky8/gpgpu/cuda/11.7/11.7.1:
 
-module-whatis	 cuda 10.0.130.1
-conflict	 cuda
-prepend-path	 CUDA_HOME /apps/cuda/10.0.130.1
-prepend-path	 CUDA_PATH /apps/cuda/10.0.130.1
-prepend-path	 PATH /apps/cuda/10.0.130.1/bin
-prepend-path	 LD_LIBRARY_PATH /apps/cuda/10.0.130.1/extras/CUPTI/lib64
-prepend-path	 LD_LIBRARY_PATH /apps/cuda/10.0.130.1/lib64
-prepend-path	 CPATH /apps/cuda/10.0.130.1/extras/CUPTI/include
-prepend-path	 CPATH /apps/cuda/10.0.130.1/include
-prepend-path	 LIBRARY_PATH /apps/cuda/10.0.130.1/lib64
-prepend-path	 MANPATH /apps/cuda/10.0.130.1/doc/man
+module-whatis   {cuda 11.7.1}
+conflict        cuda
+prepend-path    CUDA_HOME /apps/cuda/11.7.1
+prepend-path    CUDA_PATH /apps/cuda/11.7.1
+prepend-path    PATH /apps/cuda/11.7.1/bin
+prepend-path    LD_LIBRARY_PATH /apps/cuda/11.7.1/extras/CUPTI/lib64
+prepend-path    LD_LIBRARY_PATH /apps/cuda/11.7.1/lib64
+prepend-path    CPATH /apps/cuda/11.7.1/extras/CUPTI/include
+prepend-path    CPATH /apps/cuda/11.7.1/include
+prepend-path    LIBRARY_PATH /apps/cuda/11.7.1/lib64
+prepend-path    MANPATH /apps/cuda/11.7.1/doc/man
 -------------------------------------------------------------------
 ```
 
 ### Unload all loaded modules (Initialize)
 
 ```
-[username@g0001 ~]$ module purge
-[username@g0001 ~]$ module list
+[username@es1 ~]$ module purge
+[username@es1 ~]$ module list
 No Modulefiles Currently Loaded.
 ```
 
 ### Load dependent modules
 
 ```
-[username@g0001 ~]$ module load cudnn/7.6/7.6.5
-WARNING: cudnn/7.6/7.6.5 cannot be loaded due to missing prereq.
-HINT: at least one of the following modules must be loaded first: cuda/9.0 cuda/9.2 cuda/10.0 cuda/10.1 cuda/10.2
+[username@es1 ~]$ module load cudnn/8.4/8.4.1
+WARNING: cudnn/8.4/8.4.1 cannot be loaded due to missing prereq.
+HINT: at least one of the following modules must be loaded first: cuda/10.2 cuda/11.0 cuda/11.1 cuda/11.2 cuda/11.3 cuda/11.4 cuda/11.5 cuda/11.6 cuda/11.7
+
+Loading cudnn/8.4/8.4.1
+  ERROR: Module evaluation aborted
 ```
 
-Due to dependencies, you will not be able to load `cudnn/7.6/7.6.5` without loading either `cuda/9.0`, `cuda/9.2`, `cuda/10.0`, `cuda/10.1`, or `cuda/10.2` module first.
+Because of dependencies, you cannot load `cudnn/8.4/8.4.1` without first loading one of the modules from `cuda/10.2` or `cuda/11.0` to `cuda/11.7`.
 
 ```
-[username@g0001 ~]$ module load cuda/10.0/10.0.130.1
-[username@g0001 ~]$ module load cudnn/7.6/7.6.5
+[username@es1 ~]$ module load cuda/11.7/11.7.1
+[username@es1 ~]$ module load cudnn/8.4/8.4.1
 ```
 
 ### Load exclusive modules
@@ -90,40 +93,55 @@ Due to dependencies, you will not be able to load `cudnn/7.6/7.6.5` without load
 Modules that are in an exclusive relationship, such as modules of different versions of the same library, cannot be used at the same time.
 
 ```
-[username@g0001 ~]$ module load cuda/10.0/10.0.130.1
-[username@g0001 ~]$ module load cuda/10.2/10.2.89
-cuda/10.2/10.2.89(7):ERROR:150: Module 'cuda/10.2/10.2.89' conflicts with the currently loaded module(s) 'cuda/10.0/10.0.130.1'
+[username@es1 ~]$ module load cuda/11.7/11.7.1
+[username@es1 ~]$ module load cuda/12.0/12.0.0
+Loading cuda/12.0/12.0.0
+  ERROR: cuda/12.0/12.0.0 cannot be loaded due to a conflict.
+    HINT: Might try "module unload cuda" first.
 ```
 
 ### Switch modules
 
 ```
-[username@g0001 ~]$ module load cuda/10.2/10.2.89
-[username@g0001 ~]$ module switch cuda/10.2/10.2.89 cuda/11.0/11.0.3
+[username@es1 ~]$ module load cuda/11.7/11.7.1
+[username@es1 ~]$ module switch cuda/11.7/11.7.1 cuda/12.0/12.0.0
 ```
 
-Switching may not be successful if there are dependencies.
+In Interactive Node (A) and Compute Node (A) environments, switching may not be successful if there are dependencies.
 
 ```
-[username@g0001 ~]$ module load cuda/10.0/10.0.130.1
-[username@g0001 ~]$ module load cudnn/7.6/7.6.5
-[username@g0001 ~]$ module switch cuda/10.0/10.0.130.1 cuda/10.2/10.2.89
-[username@g0001 ~]$ env | grep LD_LIBRARY_PATH
-LD_LIBRARY_PATH=/apps/cudnn/7.6.5/cuda10.0/lib64:/apps/cuda/10.2.89/lib64:/apps/cuda/10.2.89/extras/CUPTI/lib64
+[username@es-a1 ~]$ module load cuda/11.0/11.0.3
+[username@es-a1 ~]$ module load cudnn/8.4/8.4.1
+[username@es-a1 ~]$ module switch cuda/11.0/11.0.3 cuda/11.2/11.2.2
+[username@es-a1 ~]$ echo $LD_LIBRARY_PATH
+/apps/cuda/11.2.2/lib64:/apps/cuda/11.2.2/extras/CUPTI/lib64:/apps/cudnn/8.4.1/cuda11.0/lib64
 ```
 
-CUDA10.2 and cuDNN for CUDA10.0 are loaded.
+CUDA 11.2 and cuDNN for CUDA 11.0 are loaded.
 
-As shown below, it is necessary to unload modules that depend on the target module in advance and reload them after switching.
+Note that in the Interactive Node (V) and Compute Node (V) environment, the `module switch` command will cause an error if there is a dependency.
 
 ```
-[username@g0001 ~]$ module load cuda/10.0/10.0.130.1
-[username@g0001 ~]$ module load cudnn/7.6/7.6.5
-[username@g0001 ~]$ module unload cudnn/7.6/7.6.5
-[username@g0001 ~]$ module switch cuda/10.0/10.0.130.1 cuda/10.2/10.2.89
-[username@g0001 ~]$ module load cudnn/7.6/7.6.5
-[username@g0001 ~]$ env | grep LD_LIBRARY_PATH
-LD_LIBRARY_PATH=/apps/cudnn/7.6.5/cuda10.2/lib64:/apps/cuda/10.2.89/lib64:/apps/cuda/10.2.89/extras/CUPTI/lib64
+[username@es1 ~]$ module load cuda/11.0/11.0.3
+[username@es1 ~]$ module load cudnn/8.4/8.4.1
+[username@es1 ~]$ module switch cuda/11.0/11.0.3 cuda/11.2/11.2.2
+Unloading cuda/11.0/11.0.3
+  ERROR: cuda/11.0/11.0.3 cannot be unloaded due to a prereq.
+    HINT: Might try "module unload cudnn/8.4/8.4.1" first.
+
+Switching from cuda/11.0/11.0.3 to cuda/11.2
+  ERROR: Unload of switched-off cuda/11.0/11.0.3 failed
+```
+
+In the Interactive Node (A) and Compute Node (A) environments, unload the modules that depend on the target module in advance and load them again after switching.
+
+```
+[username@es-a1 ~]$ module load cuda/11.0/11.0.3 cudnn/8.4/8.4.1
+[username@es-a1 ~]$ module unload cudnn/8.4/8.4.1
+[username@es-a1 ~]$ module switch cuda/11.0/11.0.3 cuda/11.2/11.2.2
+[username@es-a1 ~]$ module load cudnn/8.4/8.4.1
+[username@es-a1 ~]$ echo $LD_LIBRARY_PATH
+/apps/cudnn/8.4.1/cuda11.2/lib64:/apps/cuda/11.2.2/lib64:/apps/cuda/11.2.2/extras/CUPTI/lib64
 ```
 
 ## Usage in a job script
@@ -134,12 +152,12 @@ sh, bash:
 
 ```
 source /etc/profile.d/modules.sh
-module load cuda/10.0/10.0.130.1
+module load cuda/10.2/10.2.89
 ```
 
 csh, tcsh:
 
 ```
 source /etc/profile.d/modules.csh
-module load cuda/10.0/10.0.130.1
+module load cuda/10.2/10.2.89
 ```

--- a/ja/docs/environment-modules.md
+++ b/ja/docs/environment-modules.md
@@ -30,59 +30,62 @@ $ module [options] <sub-command> [sub-command options]
 ### モジュールのロード {#load-modules}
 
 ```
-[username@g0001 ~]$ module load cuda/10.0/10.0.130.1 cudnn/7.6/7.6.5
+[username@es1 ~]$ module load cuda/11.7/11.7.1 cudnn/8.4/8.4.1
 ```
 
 ### ロード済みのモジュールの一覧表示 {#list-loaded-modules}
 
 ```
-[username@g0001 ~]$ module list
+[username@es1 ~]$ module list
 Currently Loaded Modulefiles:
-  1) cuda/10.0/10.0.130.1   2) cudnn/7.6/7.6.5
+ 1) cuda/11.7/11.7.1   2) cudnn/8.4/8.4.1
 ```
 
 ### モジュールの設定内容の表示 {#display-the-configuration-of-modules}
 
 ```
-[username@g0001 ~]$ module show cuda/10.0/10.0.130.1
+[username@es1 ~]$ module show cuda/11.7/11.7.1
 -------------------------------------------------------------------
-/apps/modules/modulefiles/centos7/gpgpu/cuda/10.0/10.0.130.1:
+/apps/modules/modulefiles/rocky8/gpgpu/cuda/11.7/11.7.1:
 
-module-whatis	 cuda 10.0.130.1
-conflict	 cuda
-prepend-path	 CUDA_HOME /apps/cuda/10.0.130.1
-prepend-path	 CUDA_PATH /apps/cuda/10.0.130.1
-prepend-path	 PATH /apps/cuda/10.0.130.1/bin
-prepend-path	 LD_LIBRARY_PATH /apps/cuda/10.0.130.1/extras/CUPTI/lib64
-prepend-path	 LD_LIBRARY_PATH /apps/cuda/10.0.130.1/lib64
-prepend-path	 CPATH /apps/cuda/10.0.130.1/extras/CUPTI/include
-prepend-path	 CPATH /apps/cuda/10.0.130.1/include
-prepend-path	 LIBRARY_PATH /apps/cuda/10.0.130.1/lib64
-prepend-path	 MANPATH /apps/cuda/10.0.130.1/doc/man
+module-whatis   {cuda 11.7.1}
+conflict        cuda
+prepend-path    CUDA_HOME /apps/cuda/11.7.1
+prepend-path    CUDA_PATH /apps/cuda/11.7.1
+prepend-path    PATH /apps/cuda/11.7.1/bin
+prepend-path    LD_LIBRARY_PATH /apps/cuda/11.7.1/extras/CUPTI/lib64
+prepend-path    LD_LIBRARY_PATH /apps/cuda/11.7.1/lib64
+prepend-path    CPATH /apps/cuda/11.7.1/extras/CUPTI/include
+prepend-path    CPATH /apps/cuda/11.7.1/include
+prepend-path    LIBRARY_PATH /apps/cuda/11.7.1/lib64
+prepend-path    MANPATH /apps/cuda/11.7.1/doc/man
 -------------------------------------------------------------------
 ```
 
 ### ロード済みのすべてのモジュールをアンロード（初期化） {#unload-all-loaded-modules-initialize}
 
 ```
-[username@g0001 ~]$ module purge
-[username@g0001 ~]$ module list
+[username@es1 ~]$ module purge
+[username@es1 ~]$ module list
 No Modulefiles Currently Loaded.
 ```
 
 ### 依存関係のあるモジュールのロード {#load-dependent-modules}
 
 ```
-[username@g0001 ~]$ module load cudnn/7.6/7.6.5
-WARNING: cudnn/7.6/7.6.5 cannot be loaded due to missing prereq.
-HINT: at least one of the following modules must be loaded first: cuda/9.0 cuda/9.2 cuda/10.0 cuda/10.1 cuda/10.2
+[username@es1 ~]$ module load cudnn/8.4/8.4.1
+WARNING: cudnn/8.4/8.4.1 cannot be loaded due to missing prereq.
+HINT: at least one of the following modules must be loaded first: cuda/10.2 cuda/11.0 cuda/11.1 cuda/11.2 cuda/11.3 cuda/11.4 cuda/11.5 cuda/11.6 cuda/11.7
+
+Loading cudnn/8.4/8.4.1
+  ERROR: Module evaluation aborted
 ```
 
-依存関係があるため、`cuda/9.0`、`cuda/9.2`、`cuda/10.0`、`cuda/10.1`、`cuda/10.2`のいずれかのモジュールを先にロードしないと`cudnn/7.6/7.6.5`をロードできません。
+依存関係があるため、`cuda/10.2`、`cuda/11.0`から`cuda/11.7`のいずれかのモジュールを先にロードしないと`cudnn/8.4/8.4.1`をロードできません。
 
 ```
-[username@g0001 ~]$ module load cuda/10.0/10.0.130.1
-[username@g0001 ~]$ module load cudnn/7.6/7.6.5
+[username@es1 ~]$ module load cuda/11.7/11.7.1
+[username@es1 ~]$ module load cudnn/8.4/8.4.1
 ```
 
 ### 排他関係にあるモジュールのロード {#load-exclusive-modules}
@@ -90,40 +93,55 @@ HINT: at least one of the following modules must be loaded first: cuda/9.0 cuda/
 同一ライブラリの異なるバージョンのモジュールなど、排他関係にあるモジュールは同時に利用することはできません。
 
 ```
-[username@g0001 ~]$ module load cuda/10.0/10.0.130.1
-[username@g0001 ~]$ module load cuda/10.2/10.2.89
-cuda/10.2/10.2.89(7):ERROR:150: Module 'cuda/10.2/10.2.89' conflicts with the currently loaded module(s) 'cuda/10.0/10.0.130.1'
+[username@es1 ~]$ module load cuda/11.7/11.7.1
+[username@es1 ~]$ module load cuda/12.0/12.0.0
+Loading cuda/12.0/12.0.0
+  ERROR: cuda/12.0/12.0.0 cannot be loaded due to a conflict.
+    HINT: Might try "module unload cuda" first.
 ```
 
 ### モジュールの切り替え {#switch-modules}
 
 ```
-[username@g0001 ~]$ module load cuda/10.2/10.2.89
-[username@g0001 ~]$ module switch cuda/10.2/10.2.89 cuda/11.0/11.0.3
+[username@es1 ~]$ module load cuda/11.7/11.7.1
+[username@es1 ~]$ module switch cuda/11.7/11.7.1 cuda/12.0/12.0.0
 ```
 
-依存関係があると切り替えがうまくできない場合があります。
+インタラクティブノード(A)、計算ノード(A)環境では依存関係があると切り替えがうまくできない場合があります。
 
 ```
-[username@g0001 ~]$ module load cuda/10.0/10.0.130.1
-[username@g0001 ~]$ module load cudnn/7.6/7.6.5
-[username@g0001 ~]$ module switch cuda/10.0/10.0.130.1 cuda/10.2/10.2.89
-[username@g0001 ~]$ env | grep LD_LIBRARY_PATH
-LD_LIBRARY_PATH=/apps/cudnn/7.6.5/cuda10.0/lib64:/apps/cuda/10.2.89/lib64:/apps/cuda/10.2.89/extras/CUPTI/lib64
+[username@es-a1 ~]$ module load cuda/11.0/11.0.3
+[username@es-a1 ~]$ module load cudnn/8.4/8.4.1
+[username@es-a1 ~]$ module switch cuda/11.0/11.0.3 cuda/11.2/11.2.2
+[username@es-a1 ~]$ echo $LD_LIBRARY_PATH
+/apps/cuda/11.2.2/lib64:/apps/cuda/11.2.2/extras/CUPTI/lib64:/apps/cudnn/8.4.1/cuda11.0/lib64
 ```
 
-CUDA10.2と、CUDA10.0用のcuDNNがロードされた状態になっています。
+CUDA11.2と、CUDA11.0用のcuDNNがロードされた状態になっています。
 
-以下のように対象のモジュールに依存しているモジュールを事前にアンロード、切り替え後の再ロードする必要があります。
+なお、インタラクティブノード(V)、計算ノード(V)環境では依存関係がある場合は`module switch`コマンドがエラーを返します。
 
 ```
-[username@g0001 ~]$ module load cuda/10.0/10.0.130.1
-[username@g0001 ~]$ module load cudnn/7.6/7.6.5
-[username@g0001 ~]$ module unload cudnn/7.6/7.6.5
-[username@g0001 ~]$ module switch cuda/10.0/10.0.130.1 cuda/10.2/10.2.89
-[username@g0001 ~]$ module load cudnn/7.6/7.6.5
-[username@g0001 ~]$ env | grep LD_LIBRARY_PATH
-LD_LIBRARY_PATH=/apps/cudnn/7.6.5/cuda10.2/lib64:/apps/cuda/10.2.89/lib64:/apps/cuda/10.2.89/extras/CUPTI/lib64
+[username@es1 ~]$ module load cuda/11.0/11.0.3
+[username@es1 ~]$ module load cudnn/8.4/8.4.1
+[username@es1 ~]$ module switch cuda/11.0/11.0.3 cuda/11.2/11.2.2
+Unloading cuda/11.0/11.0.3
+  ERROR: cuda/11.0/11.0.3 cannot be unloaded due to a prereq.
+    HINT: Might try "module unload cudnn/8.4/8.4.1" first.
+
+Switching from cuda/11.0/11.0.3 to cuda/11.2
+  ERROR: Unload of switched-off cuda/11.0/11.0.3 failed
+```
+
+インタラクティブノード(A)、計算ノード(A)環境では以下のように、対象のモジュールに依存しているモジュールを事前にアンロードし、切り替え後に再度ロードしてください。
+
+```
+[username@es-a1 ~]$ module load cuda/11.0/11.0.3 cudnn/8.4/8.4.1
+[username@es-a1 ~]$ module unload cudnn/8.4/8.4.1
+[username@es-a1 ~]$ module switch cuda/11.0/11.0.3 cuda/11.2/11.2.2
+[username@es-a1 ~]$ module load cudnn/8.4/8.4.1
+[username@es-a1 ~]$ echo $LD_LIBRARY_PATH
+/apps/cudnn/8.4.1/cuda11.2/lib64:/apps/cuda/11.2.2/lib64:/apps/cuda/11.2.2/extras/CUPTI/lib64
 ```
 
 ## ジョブスクリプトでの利用方法 {#usage-in-a-job-script}
@@ -134,12 +152,12 @@ sh, bashの場合:
 
 ```
 source /etc/profile.d/modules.sh
-module load cuda/10.0/10.0.130.1
+module load cuda/10.2/10.2.89
 ```
 
 csh, tcshの場合:
 
 ```
 source /etc/profile.d/modules.csh
-module load cuda/10.0/10.0.130.1
+module load cuda/10.2/10.2.89
 ```


### PR DESCRIPTION
2023年度のモジュール構成に併せて、例で使用しているモジュールのバージョンを更新しました。

変更点:
* Rocky Linux 8をサポート開始したCUDA 11.7系を使用。
* cuDNNはCUDA 11.7系をサポート開始しているバージョンを使用。
* それ以外はABCIでサポートしている最小バージョンを使用。
* ログインしているノードを計算ノードからインタラクティブノードに変更。