### PR TITLE
Fj20230421 00

### DIFF
--- a/en/docs/tips/spack.md
+++ b/en/docs/tips/spack.md
@@ -37,9 +37,19 @@ After that, you can use Spack by loading a setup shell script.
 
 #### Adding Compilers {#adding-compilers}
 
-First, you have to register compilers you want to use in Spack.
+First, register the compiler to be used in Spack by `spack compiler find` command.
 
-`spack compiler list` command automatically detects and registers compilers which are located in the default path (/usr/bin).
+```Console
+[username@es1 ~]$ spack compiler find
+==> Added 2 new compilers to ${HOME}/.spack/linux/compilers.yaml
+    gcc@8.5.0  clang@13.0.1
+==> Compilers are defined in the following files:
+    ${HOME}/.spack/linux/compilers.yaml
+```
+
+`spack compiler list` command shows registered compilers.
+
+GCC 8.5.0 is located in the default path (/usr/bin), so automatically detected and registered.
 
 ```Console
 [username@es1 ~]$ spack compiler list
@@ -65,7 +75,7 @@ Compute Node (A)
 
 ```Console
 [username@es-a1 ~]$ cp /apps/spack/anode/compilers.yaml ${HOME}/.spack/linux/
-[username@es-a1 ~]:$ spack compiler list
+[username@es-a1 ~]$ spack compiler list
 ==> Available compilers
 -- gcc rhel8-x86_64 ---------------------------------------------
 gcc@12.2.0  gcc@8.3.1

--- a/en/docs/tips/spack.md
+++ b/en/docs/tips/spack.md
@@ -155,7 +155,7 @@ gcc@12.2.0  gcc@8.3.1
 `compiler info` sub-command shows the detail of a specific compiler.
 
 ```Console
-sername@es1 ~]$ spack compiler info gcc@8.5.0
+[username@es1 ~]$ spack compiler info gcc@8.5.0
 gcc@8.5.0:
         paths:
              cc = /usr/bin/gcc
@@ -279,7 +279,7 @@ Description:
 (snip)
 ```
 
-`versions` sub-command shows avaitable versions for a specific software.
+`versions` sub-command shows available versions for a specific software.
 
 ```Console
 [username@es1 ~]$ spack versions openmpi

--- a/ja/docs/tips/spack.md
+++ b/ja/docs/tips/spack.md
@@ -37,7 +37,16 @@ GitHubからcloneし、使用するバージョンをcheckoutすることで、S
 
 #### コンパイラの登録 {#adding-compilers}
 
-Spackで使用するコンパイラをSpackに登録します。
+Spackで使用するコンパイラを`spack compiler find`コマンドでSpackに登録します。
+
+```Console
+[username@es1 ~]$ spack compiler find
+==> Added 2 new compilers to ${HOME}/.spack/linux/compilers.yaml
+    gcc@8.5.0  clang@13.0.1
+==> Compilers are defined in the following files:
+    ${HOME}/.spack/linux/compilers.yaml
+```
+
 登録されたコンパイラは`spack compiler list`コマンドで確認できます。
 
 GCC 8.5.0は標準のパス（/usr/bin）に入っているため、Spackが自動的に見つけます。
@@ -68,7 +77,7 @@ gcc@12.2.0  gcc@8.5.0
 
 ```Console
 [username@es-a1 ~]$ cp /apps/spack/anode/compilers.yaml ${HOME}/.spack/linux/
-[username@es-a1 ~]:$ spack compiler list
+[username@es-a1 ~]$ spack compiler list
 ==> Available compilers
 -- gcc rhel8-x86_64 ---------------------------------------------
 gcc@12.2.0  gcc@8.3.1

--- a/ja/docs/tips/spack.md
+++ b/ja/docs/tips/spack.md
@@ -393,7 +393,7 @@ Spackでは、同一ソフトウェアを異なる設定で複数インストー
 
 #### 使い方 {#how-to-use}
 
-「CCUDA 11.8.0を使用するOpenMPI 4.1.4」を使う場合の利用方法を説明します。
+「CUDA 11.8.0を使用するOpenMPI 4.1.4」を使う場合の利用方法を説明します。
 
 `spack load`実行時にOpenMPIのバージョン並びにCUDAの依存関係を指定することで、特定のバージョンを利用することが可能です。
 
@@ -502,9 +502,9 @@ mpiexec -n ${NMPIPROC} -map-by ppr:${NPPN}:node dbcast $SRC_FILE $DST_FILE
 ```
 
 
-### ソフトウェア環境からのSinguarityイメージの作成手順 {#build-singularity-image-from-environment}
+### ソフトウェア環境からのSingularityイメージの作成手順 {#build-singularity-image-from-environment}
 
-[ソフトウェア環境の定義と利用](#using-environments)で作成した環境を用いてSingurarityのイメージを作成することが可能です。
+[ソフトウェア環境の定義と利用](#using-environments)で作成した環境を用いてSingularityのイメージを作成することが可能です。
 ここではmyenvという名前のSpack環境を用いてCUDA-awareのOpenMPIをインストールし、Singularityイメージを作成する例を示します。
 
 ```Console


### PR DESCRIPTION
Spackの設定方法に関する修正です。ご確認のほどよろしくお願いいたします。

初めてSpackをインストールした際、`spack compiler find`を実行せずに`spack compiler list`を実行すると、以下のエラーが発生して`spack compiler find`の実行を求められます。
```
[username@es1 ~]$ spack compiler list
==> No compilers available. Run `spack compiler find` to autodetect compilers
```
