### PR TITLE
Corrected a column name in the table.

### DIFF
--- a/en/docs/mpi.md
+++ b/en/docs/mpi.md
@@ -21,7 +21,7 @@ The following is a list MPI versions installed in the ABCI system.
 
 ## NVIDIA HPC-X
 
-| Module Version | MPI Version |  Compute Node (V) | Compute Node (A) |
+| Module Version | Open MPI Version |  Compute Node (V) | Compute Node (A) |
 | :-- | :-- | :-- | :-- |
 | 2.12 | 4.1.5a1 | Yes | Yes |
 

--- a/ja/docs/mpi.md
+++ b/ja/docs/mpi.md
@@ -21,7 +21,7 @@ ABCIシステムでは、以下のMPIを利用できます。
 
 ## NVIDIA HPC-X
 
-| Module Version | MPI Version |  Compute Node (V) | Compute Node (A) |
+| Module Version | Open MPI Version |  Compute Node (V) | Compute Node (A) |
 | :-- | :-- | :-- | :-- |
 | 2.12 | 4.1.5a1 | Yes | Yes |
 


### PR DESCRIPTION
HPC-Xの章において、テーブルの列名が"MPI Version"となっています。
これだとMPIの仕様バージョンにみえるため"Open MPI Version"としました。