### PR TITLE
Removed Google Analytics configuration.

### DIFF
--- a/portal/root/mkdocs.yml
+++ b/portal/root/mkdocs.yml
@@ -3,9 +3,6 @@ site_description: ABCI Portal Guide
 site_author: AIST
 site_url: https://docs.abci.ai/portal/
 copyright: 'Copyright &copy; 2018 National Institute of Advanced Industrial Science and Technology (AIST)'
-google_analytics:
-  - 'UA-118371652-2'
-  - 'auto'
 nav: []
 theme:
   name: 'material'

--- a/portal/root/mkdocs.yml
+++ b/portal/root/mkdocs.yml
@@ -8,6 +8,7 @@ theme:
   name: 'material'
   palette:
     primary: 'blue'
+  custom_dir: overrides
 plugins:
   - redirects:
       redirect_maps:

--- a/portal/root/overrides/main.html
+++ b/portal/root/overrides/main.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  <script defer data-domain="docs.abci.ai" src="https://analytics.abci.ai/js/plausible.js"></script>
+{% endblock %}

--- a/root/mkdocs.yml
+++ b/root/mkdocs.yml
@@ -14,6 +14,7 @@ theme:
   logo: 'img/logo.png'
   palette:
     primary: 'red'
+  custom_dir: overrides
 markdown_extensions:
   - admonition
 plugins:

--- a/root/mkdocs.yml
+++ b/root/mkdocs.yml
@@ -3,9 +3,6 @@ site_description: ABCI User Guide & Portal Guide
 site_author: AIST
 site_url: https://docs.abci.ai/
 copyright: 'Copyright &copy; 2018 National Institute of Advanced Industrial Science and Technology (AIST)'
-google_analytics:
-  - 'UA-118371652-2'
-  - 'auto'
 nav:
   - 'ABCI User Guide 日本語版': 'https://docs.abci.ai/ja/'
   - 'ABCI User Guide English version': 'https://docs.abci.ai/en/'

--- a/root/overrides/main.html
+++ b/root/overrides/main.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  <script defer data-domain="docs.abci.ai" src="https://analytics.abci.ai/js/plausible.js"></script>
+{% endblock %}


### PR DESCRIPTION
root/mkdocs.yml設定ファイルからGoogle Analyticsの設定を削除する修正です。
修正後、makeでコンテンツを生成したのち、site/以下のhtmlファイルにGoogle Analyticsのタグ(UA-)が含まれないことを確認しました。

また、root、portal/root以下にPlausible Analyticsの設定を追加しました。
修正後、privacy-policy/index.html、404.htmlページにPlausible Analyticsのタグが設定されることを確認しました。