### PR TITLE
Unified translation.

### DIFF
--- a/en/docs/abci-cloudstorage.md
+++ b/en/docs/abci-cloudstorage.md
@@ -35,4 +35,4 @@ As for charge coefficient of ABCI Cloud Storage, see [this page](https://abci.ai
 | [Usage](abci-cloudstorage/usage.md) | This section shows basic usage. |
 | [Encryption](abci-cloudstorage/encryption.md) | This section explains encryption. |
 | [Access Control (1)](abci-cloudstorage/acl.md) | This section shows how to control accessibility by ACL. Data can be shared between groups. |
-| [Access Control (2)](abci-cloudstorage/policy.md) | This section explains access control which is applicable to buckets and user accounts. It is possible to set access control that cannot be done with ACL. Settings for buckets can be done with a User Account, but Usage Managers Account is necessary to set for accounts. |
+| [Access Control (2)](abci-cloudstorage/policy.md) | This section explains access control which is applicable to buckets and user accounts. It is possible to set access control that cannot be done with ACL. Settings for buckets can be done with Cloud Storage Account for users, but Cloud Storage Account for managers is necessary to set for accounts. |

--- a/en/docs/abci-cloudstorage.md
+++ b/en/docs/abci-cloudstorage.md
@@ -35,4 +35,4 @@ As for charge coefficient of ABCI Cloud Storage, see [this page](https://abci.ai
 | [Usage](abci-cloudstorage/usage.md) | This section shows basic usage. |
 | [Encryption](abci-cloudstorage/encryption.md) | This section explains encryption. |
 | [Access Control (1)](abci-cloudstorage/acl.md) | This section shows how to control accessibility by ACL. Data can be shared between groups. |
-| [Access Control (2)](abci-cloudstorage/policy.md) | This section explains access control which is applicable to buckets and user accounts. It is possible to set access control that cannot be done with ACL. Settings for buckets can be done with Cloud Storage Account for users, but Cloud Storage Account for managers is necessary to set for accounts. |
+| [Access Control (2)](abci-cloudstorage/policy.md) | This section explains access control which is applicable to buckets and user accounts. It is possible to set access control that cannot be done with ACL. Access crontrol settings for buckets can be done with a 'Cloud Storage Account for user', but 'Cloud Storage Account for manager' is necessary to set for access control settings for accounts. |

--- a/en/docs/abci-cloudstorage.md
+++ b/en/docs/abci-cloudstorage.md
@@ -35,4 +35,4 @@ As for charge coefficient of ABCI Cloud Storage, see [this page](https://abci.ai
 | [Usage](abci-cloudstorage/usage.md) | This section shows basic usage. |
 | [Encryption](abci-cloudstorage/encryption.md) | This section explains encryption. |
 | [Access Control (1)](abci-cloudstorage/acl.md) | This section shows how to control accessibility by ACL. Data can be shared between groups. |
-| [Access Control (2)](abci-cloudstorage/policy.md) | This section explains access control which is applicable to buckets and user accounts. It is possible to set access control that cannot be done with ACL. Settings for buckets can be done with a User Account, but User Administrators Account is necessary to set for accounts. |
+| [Access Control (2)](abci-cloudstorage/policy.md) | This section explains access control which is applicable to buckets and user accounts. It is possible to set access control that cannot be done with ACL. Settings for buckets can be done with a User Account, but Usage Managers Account is necessary to set for accounts. |

--- a/en/docs/abci-cloudstorage.md
+++ b/en/docs/abci-cloudstorage.md
@@ -16,8 +16,8 @@ ABCI Cloud Storage has unique capabilities.
 
     Users can encrypt data transfers between clients and the storage. Users can also encrypt data and store encrypted data in the storage.
 
-To start using ABCI Cloud Storage, Usage Manager of each ABCI group should apply for use on [ABCI User Portal](https://portal.abci.ai/user/).
-If you are not a Usage Manager, please contact to Usage Managers of your group.
+To start using ABCI Cloud Storage, User Administrator of each ABCI group should apply for use on [ABCI User Portal](https://portal.abci.ai/user/).
+If you are not a User Administrator, please contact to User Administrators of your group.
 For details of the operation, refer to [ABCI Portal Guide](https://docs.abci.ai/portal/en/).
 
 ABCI points based on the total size of objects in buckets owned by your ABCI group are subtracted from your ABCI group's each day. There is no charge for data transfer or API calls. Users can check the total size by [show_cs_usage](getting-started.md#check-cloud-storage-usage). The calculation formula of ABCI points for using ABCI Cloud Storage is as follows.
@@ -35,4 +35,4 @@ As for charge coefficient of ABCI Cloud Storage, see [this page](https://abci.ai
 | [Usage](abci-cloudstorage/usage.md) | This section shows basic usage. |
 | [Encryption](abci-cloudstorage/encryption.md) | This section explains encryption. |
 | [Access Control (1)](abci-cloudstorage/acl.md) | This section shows how to control accessibility by ACL. Data can be shared between groups. |
-| [Access Control (2)](abci-cloudstorage/policy.md) | This section explains access control which is applicable to buckets and user accounts. It is possible to set access control that cannot be done with ACL. Settings for buckets can be done with a User Account, but Usage Managers Account is necessary to set for accounts. |
+| [Access Control (2)](abci-cloudstorage/policy.md) | This section explains access control which is applicable to buckets and user accounts. It is possible to set access control that cannot be done with ACL. Settings for buckets can be done with a User Account, but User Administrators Account is necessary to set for accounts. |

--- a/en/docs/abci-cloudstorage/cs-account.md
+++ b/en/docs/abci-cloudstorage/cs-account.md
@@ -19,7 +19,7 @@ An ABCI user can own at most 10 Cloud Storage Accounts per group. If an ABCI use
 
 This account is only given to User Administrators and allow them to control accessibility. For more information, see [Access Control(2)](policy.md).
 
-Even though Usage Managers can use this account in order to perform what users can do such as uploading or downloading data, they are basically supposed to use rather their Users Account than Usage Managers Account to do so.
+Even though User Administrators can use the 'Cloud Storage Account for managers' in order to perform what 'Cloud Storage Account for users' can do such as uploading or downloading data, it is basically supposed to use rather 'Cloud Storage Account for user' than 'Cloud Storage Account for manager' to do so.
 
 The Cloud Storage Account for Manager is issued to every single User Administrator. If a user is a User Administrator for two groups, two accounts are given to her/him.
 

--- a/en/docs/abci-cloudstorage/cs-account.md
+++ b/en/docs/abci-cloudstorage/cs-account.md
@@ -3,7 +3,7 @@
 
 ## Cloud Storage Account
 
-There are two types of accounts. The one is 'Cloud Storage Account for user' and the other is 'Cloud Storage Account for manager'. Cloud Storage Account for user is issued to each ABCI user per ABCI group. Both Cloud Storage Account for user and Cloud Storage Account for manager are issued to Usage Managers.
+There are two types of accounts. The one is 'Cloud Storage Account for user' and the other is 'Cloud Storage Account for manager'. Cloud Storage Account for user is issued to each ABCI user per ABCI group. Both Cloud Storage Account for user and Cloud Storage Account for manager are issued to User Administrators.
 
 ### Cloud Storage Account for User
 
@@ -17,11 +17,11 @@ An ABCI user can own at most 10 Cloud Storage Accounts per group. If an ABCI use
 
 ### Cloud Storage Account for Manager
 
-This account is only given to Usage Managers and allow them to control accessibility. For more information, see [Access Control(2)](policy.md).
+This account is only given to User Administrators and allow them to control accessibility. For more information, see [Access Control(2)](policy.md).
 
 Even though Usage Managers can use this account in order to perform what users can do such as uploading or downloading data, they are basically supposed to use rather their Users Account than Usage Managers Account to do so.
 
-The Cloud Storage Account for Manager is issued to every single Usage Manager. If a user is a Usage Manager for two groups, two accounts are given to her/him.
+The Cloud Storage Account for Manager is issued to every single User Administrator. If a user is a User Administrator for two groups, two accounts are given to her/him.
 
 ## Access Key
 

--- a/en/docs/abci-cloudstorage/policy.md
+++ b/en/docs/abci-cloudstorage/policy.md
@@ -7,7 +7,7 @@ There are two types of "Access Control Policy": "Bucket Policy" and "User Policy
 * Bucket Policy: Set an access control policy for the bucket.
 * User Policy: Set access control policies for your ABCI Cloud Storage account.
 
-"Bucket Policy" can be set with the Users Account, but Usage Managers Account is necessary to set "User Policy". If your ABCI Cloud Storage account is Users Account, ask Usage Managers to change the accessibility or to grant you appropriate permission.
+"Bucket Policy" can be set with the Users Account, but Usage Managers Account is necessary to set "User Policy". If your ABCI Cloud Storage account is Users Account, ask User Administrators to change the accessibility or to grant you appropriate permission.
 
 ## Default Permission 
 

--- a/en/docs/abci-cloudstorage/policy.md
+++ b/en/docs/abci-cloudstorage/policy.md
@@ -7,7 +7,7 @@ There are two types of "Access Control Policy": "Bucket Policy" and "User Policy
 * Bucket Policy: Set an access control policy for the bucket.
 * User Policy: Set access control policies for your ABCI Cloud Storage account.
 
-"Bucket Policy" can be set with the Users Account, but Usage Managers Account is necessary to set "User Policy". If your ABCI Cloud Storage account is Users Account, ask User Administrators to change the accessibility or to grant you appropriate permission.
+"Bucket Policy" can be set with the Cloud Storage Account for user, but Cloud Storage Account for manager is necessary to set "User Policy". If your ABCI Cloud Storage Account is which for Users, ask User Administrators to change the accessibility or to grant you appropriate permission.
 
 ## Default Permission 
 
@@ -104,7 +104,7 @@ This part explains how to share a bucket between ABCI groups.
 In this example, two ABCI cloud storage accounts bbb00000.1 and bbb00001.1 belonging to Group B are granted access to the 'share-bucket' bucket owned by Group A.
 
 Firstly, a user in Group B executes the command `aws iam get-user` to obtain the Arn values for users bbb00000.1 and bbb00001.1 whose access is to be allowed.
-To execute the command `aws iam get-user`, Usage Managers Account is necessary.
+To execute the command `aws iam get-user`, Cloud Storage Account for manager is necessary.
 
 ```
 [username@es1 ~]$ aws --endpoint-url https://s3.abci.ai iam get-user --user-name bbb00000.1 --query User.Arn

--- a/en/docs/getting-started.md
+++ b/en/docs/getting-started.md
@@ -8,22 +8,22 @@ To use an ABCI account, determine the research and development theme according t
 Please refer to the price list in [ABCI USAGE FEES](https://abci.ai/en/how_to_use/tariffs.html) and purchase ABCI points to pay the usage fee. Please purchase ABCI points for each ABCI group. At the time of application, a minimum of 1,000 ABCI points must be purchased.
 
 ### Types of ABCI accounts {#account-type}
-There are three types of ABCI accounts: "Responsible Person", "Usage Manager", "User".
+There are three types of ABCI accounts: "Responsible Person", "User Administrator", "User".
 To use the ABCI system, the "Responsible Person" must submit a new "ABCI application" on the [ABCI User Portal](https://portal.abci.ai/user/project_register_app.php?lang=en) and obtain an ABCI group and one or more ABCI accounts. See the [ABCI Portal Guide](https://docs.abci.ai/portal/en/) for more details.
 
 !!! Note
     - An ABCI account will also be issued to the "Responsible Person".
-    - The "Responsible Person" can change "User" to "Usage Manager" on the [ABCI User Portal](https://portal.abci.ai/user/).
-    - The "Responsible Person" and "Usage Manager" can add "Usage Managers" or "Users" to the ABCI group.
-    - The "Responsible Person" and "Usage Manager" can change the "Responsible Person" of the ABCI group.
+    - The "Responsible Person" can change "User" to "User Administrator" on the [ABCI User Portal](https://portal.abci.ai/user/).
+    - The "Responsible Person" and "User Administrator" can add "User Administrators" or "Users" to the ABCI group.
+    - The "Responsible Person" and "User Administrator" can change the "Responsible Person" of the ABCI group.
 
 ### Uniqueness of the ABCI account {#account-uniqueness}
 As a general rule, each person should have a unique ABCI account. For example, it is not allowed that a company gets one ABCI account with use shared among more than one employees. On the other hand, if one person belongs to multiple corporations, that person may obtain multiple ABCI accounts. In such cases, the ABCI account corresponding to each corporation must be used appropriately.
 
 ### Persons belonging to multiple ABCI groups {#multi-titled-person}
-If one person is working on more than one themes in one corporation at the same time, instead of that person acquiring multiple ABCI accounts, such a person will belong to multiple ABCI groups with one ABCI account. In such cases, each ABCI group must be used appropriately according to the purpose of use. When unsure of which ABCI group to use, please contact the "Responsible Person" or "Usage Manager" of the ABCI group. The "Responsible Person" or "Usage Manager" of the ABCI group to which you belong will be displayed on the first screen after logging in to the [ABCI User Portal](https://portal.abci.ai/user/).
+If one person is working on more than one themes in one corporation at the same time, instead of that person acquiring multiple ABCI accounts, such a person will belong to multiple ABCI groups with one ABCI account. In such cases, each ABCI group must be used appropriately according to the purpose of use. When unsure of which ABCI group to use, please contact the "Responsible Person" or "User Administrator" of the ABCI group. The "Responsible Person" or "User Administrator" of the ABCI group to which you belong will be displayed on the first screen after logging in to the [ABCI User Portal](https://portal.abci.ai/user/).
 
-Since usage determines which ABCI group bears the usage fee, please use the appropriate ABCI group according to the instructions of the "Responsible Person" or "Usage Manager" of the ABCI group.
+Since usage determines which ABCI group bears the usage fee, please use the appropriate ABCI group according to the instructions of the "Responsible Person" or "User Administrator" of the ABCI group.
 
 ## Connecting to Interactive Node
 

--- a/en/docs/job-execution.md
+++ b/en/docs/job-execution.md
@@ -500,7 +500,7 @@ To make a reservation compute node, use `qrsub` command or the ABCI User Portal.
 When the reservation is completed, a reservation ID will be issued. Please specify this reservation ID when using the reserved node.
 
 !!! warning
-    Making reservation of compute node is permitted to a Responsible Pperson or User Administrators.
+    Making reservation of compute node is permitted to a Responsible Person or User Administrators.
 
 ```
 $ qrsub options

--- a/en/docs/job-execution.md
+++ b/en/docs/job-execution.md
@@ -500,7 +500,7 @@ To make a reservation compute node, use `qrsub` command or the ABCI User Portal.
 When the reservation is completed, a reservation ID will be issued. Please specify this reservation ID when using the reserved node.
 
 !!! warning
-    Making reservation of compute node is permitted to a responsible person or a manager.
+    Making reservation of compute node is permitted to a Responsible Pperson or User Administrators.
 
 ```
 $ qrsub options
@@ -581,7 +581,7 @@ Checking the Number of Reservable Nodes for Compute Nodes(A)
 ### Cancel a reservation
 
 !!! warning
-    Canceling reservation is permitted to a responsible person or a manager.
+    Canceling reservation is permitted to a Responsible Person or User Administrators.
 
 To cancel a reservation, use the `qrdel` command or the ABCI User Portal. When canceling reservation with qrdel command, multiple reservation IDs can be specified as comma separated list. If you specify a reservation ID that does not exist or a reservation ID that you do not have deletion permission for, an error occurs and any reservations are not canceled.
 

--- a/en/docs/storage.md
+++ b/en/docs/storage.md
@@ -101,7 +101,7 @@ stripe_count:  4 stripe_size:   1048576 stripe_offset: 10
 
 ## Group Area
 
-Group area is the disk area of the Lustre file system shared by interactive and compute nodes. To use Group area, "Usage Manager" of the group needs to apply "Add group disk" via [ABCI User Portal](https://portal.abci.ai/user/). Regarding how to add group disk, please refer to [Disk Addition Request](https://docs.abci.ai/portal/en/03/#352-disk-addition-request) in the [ABCI Portal Guide](https://docs.abci.ai/portal/en/).
+Group area is the disk area of the Lustre file system shared by interactive and compute nodes. To use Group area, "User Administrator" of the group needs to apply "Add group disk" via [ABCI User Portal](https://portal.abci.ai/user/). Regarding how to add group disk, please refer to [Disk Addition Request](https://docs.abci.ai/portal/en/03/#352-disk-addition-request) in the [ABCI Portal Guide](https://docs.abci.ai/portal/en/).
 
 To find the path to your group area, use the `show_quota` command. For details, see [Checking Disk Quota](getting-started.md#checking-disk-quota).
 


### PR DESCRIPTION
ABCI の「利用管理者」を "User Administrator(s)" に統一。
クラウドストレージの管理者は AWS に合わせて "Usage Manager" とする。