### PR TITLE
Fixed PyTorch version

### DIFF
--- a/en/docs/apps/mxnet.md
+++ b/en/docs/apps/mxnet.md
@@ -88,6 +88,7 @@ Here are the steps to create a Python virtual environment and install MXNet  and
 [username@g0001 ~]$ python3 -m venv ~/venv/mxnet+horovod
 [username@g0001 ~]$ source ~/venv/mxnet+horovod/bin/activate
 (mxnet+horovod) [username@g0001 ~]$ pip3 install --upgrade pip setuptools
+(mxnet+horovod) [username@g0001 ~]$ pip3 install wheel
 (mxnet+horovod) [username@g0001 ~]$ pip3 install mxnet-cu112==1.9.1 numpy==1.23.5
 (mxnet+horovod) [username@g0001 ~]$ HOROVOD_NCCL_LINK=SHARED HOROVOD_WITH_MXNET=1 HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_NCCL_HOME=$NCCL_HOME HOROVOD_WITH_MPI=1 HOROVOD_WITHOUT_GLOO=1 pip3 install --no-cache-dir horovod==0.27.0
 ```

--- a/en/docs/apps/pytorch.md
+++ b/en/docs/apps/pytorch.md
@@ -20,7 +20,7 @@ Here are the steps to create a Python virtual environment and install PyTorch in
 [username@g0001 ~]$ python3 -m venv ~/venv/pytorch
 [username@g0001 ~]$ source ~/venv/pytorch/bin/activate
 (pytorch) [username@g0001 ~]$ pip3 install --upgrade pip setuptools
-(pytorch) [username@g0001 ~]$ pip3 install torch torchvision torchaudio
+(pytorch) [username@g0001 ~]$ pip3 install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2 --extra-index-url https://download.pytorch.org/whl/cu118
 ```
 
 With the installation, you can use PyTorch next time you want to use it by simply loading the module and activating the Python virtual environment, as follows.
@@ -90,7 +90,8 @@ Here are the steps to create a Python virtual environment and install PyTorch an
 [username@g0001 ~]$ python3 -m venv ~/venv/pytorch+horovod
 [username@g0001 ~]$ source ~/venv/pytorch+horovod/bin/activate
 (pytorch+horovod) [username@g0001 ~]$ pip3 install --upgrade pip setuptools
-(pytorch+horovod) [username@g0001 ~]$ pip3 install torch torchvision torchaudio
+(pytorch+horovod) [username@g0001 ~]$ pip3 install wheel
+(pytorch+horovod) [username@g0001 ~]$ pip3 install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2 --extra-index-url https://download.pytorch.org/whl/cu118
 (pytorch+horovod) [username@g0001 ~]$ HOROVOD_NCCL_LINK=SHARED HOROVOD_WITH_PYTORCH=1 HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_NCCL_HOME=$NCCL_HOME HOROVOD_WITHOUT_GLOO=1 pip3 install --no-cache-dir horovod==0.27.0
 ```
 

--- a/ja/docs/apps/mxnet.md
+++ b/ja/docs/apps/mxnet.md
@@ -88,6 +88,7 @@ Your job 1234567 ('run.sh') has been submitted
 [username@g0001 ~]$ python3 -m venv ~/venv/mxnet+horovod
 [username@g0001 ~]$ source ~/venv/mxnet+horovod/bin/activate
 (mxnet+horovod) [username@g0001 ~]$ pip3 install --upgrade pip setuptools
+(mxnet+horovod) [username@g0001 ~]$ pip3 install wheel
 (mxnet+horovod) [username@g0001 ~]$ pip3 install mxnet-cu112==1.9.1 numpy==1.23.5
 (mxnet+horovod) [username@g0001 ~]$ HOROVOD_NCCL_LINK=SHARED HOROVOD_WITH_MXNET=1 HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_NCCL_HOME=$NCCL_HOME HOROVOD_WITH_MPI=1 HOROVOD_WITHOUT_GLOO=1 pip3 install --no-cache-dir horovod==0.27.0
 ```

--- a/ja/docs/apps/pytorch.md
+++ b/ja/docs/apps/pytorch.md
@@ -20,7 +20,7 @@
 [username@g0001 ~]$ python3 -m venv ~/venv/pytorch
 [username@g0001 ~]$ source ~/venv/pytorch/bin/activate
 (pytorch) [username@g0001 ~]$ pip3 install --upgrade pip setuptools
-(pytorch) [username@g0001 ~]$ pip3 install torch torchvision torchaudio
+(pytorch) [username@g0001 ~]$ pip3 install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2 --extra-index-url https://download.pytorch.org/whl/cu118
 ```
 
 次回以降は、次のようにモジュールの読み込みとPython仮想環境のアクティベートだけでPyTorchを使用できます。
@@ -90,7 +90,8 @@ Your job 1234567 ('run.sh') has been submitted
 [username@g0001 ~]$ python3 -m venv ~/venv/pytorch+horovod
 [username@g0001 ~]$ source ~/venv/pytorch+horovod/bin/activate
 (pytorch+horovod) [username@g0001 ~]$ pip3 install --upgrade pip setuptools
-(pytorch+horovod) [username@g0001 ~]$ pip3 install torch torchvision torchaudio
+(pytorch+horovod) [username@g0001 ~]$ pip3 install wheel
+(pytorch+horovod) [username@g0001 ~]$ pip3 install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2 --extra-index-url https://download.pytorch.org/whl/cu118
 (pytorch+horovod) [username@g0001 ~]$ HOROVOD_NCCL_LINK=SHARED HOROVOD_WITH_PYTORCH=1 HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_NCCL_HOME=$NCCL_HOME HOROVOD_WITHOUT_GLOO=1 pip3 install --no-cache-dir horovod==0.27.0
 ```
 


### PR DESCRIPTION
* PyTorchのインストールバージョンを2.0.1を指定するようにしました。
  * [PyTorchのドキュメント](https://pytorch.org/get-started/previous-versions/#linux-and-windows-3)では、 `--index-url`オプションでリポジトリを指定していますが、この場合litパッケージが足りずインストールに失敗します。そのため、litパッケージなどの足りないパッケージはPyPIから取得できるよう`--extra-index-url`オプションに変更しました。
* PyTorch+Horovod、MXNet+Horovodインストール時にwheelパッケージをインストールするようにしました。
  * PEP 517のビルドに対応していないHorovodでは、pip 23.1以降wheelパッケージがインストールされていない場合にビルドが失敗するためです。
    * 参考: [Deprecate call to setup.py install when wheel is absent for source distributions without pyproject.toml](https://github.com/pypa/pip/issues/8559)
  * TensorFlowの場合は、TensorFlowのインストール時にwheelパッケージが追加インストールされるためHorovodのビルドエラーは発生しません。

