### PR TITLE
Redirect to ABCI 3.0 User Guide

### DIFF
--- a/en/overrides/main.html
+++ b/en/overrides/main.html
@@ -3,3 +3,9 @@
 {% block extrahead %}
   <script defer data-domain="docs.abci.ai" src="https://analytics.abci.ai/js/plausible.js"></script>
 {% endblock %}
+
+{% block announce %}
+<p>This document is for ABCI 2.0 and may differ from the current version.
+For the latest documentation, please see <a href="https://docs.abci.ai/v3/en/">ABCI 3.0 User Guide</a>.
+</p>
+{% endblock %}

--- a/ja/overrides/main.html
+++ b/ja/overrides/main.html
@@ -3,3 +3,8 @@
 {% block extrahead %}
   <script defer data-domain="docs.abci.ai" src="https://analytics.abci.ai/js/plausible.js"></script>
 {% endblock %}
+
+{% block announce %}
+<p>このドキュメントはABCI 2.0向けの内容であり、現在の仕様とは異なる箇所があります。
+最新のドキュメントは<a href="https://docs.abci.ai/v3/ja/">ABCI 3.0ユーザーガイド</a>をご確認ください。</p>
+{% endblock %}

--- a/root/mkdocs.yml
+++ b/root/mkdocs.yml
@@ -20,4 +20,4 @@ markdown_extensions:
 plugins:
   - redirects:
       redirect_maps:
-        'index.md': 'https://docs.abci.ai/ja/'
+        'index.md': 'https://docs.abci.ai/v3/ja/'


### PR DESCRIPTION
ABCI 2.0のルート(`https://docs.abci.ai/`)訪問時にABCI 3.0日本語版(`https://docs.abci.ai/v3/ja/`)へリダイレクトする修正Pull Requestです。

また、ABCI 2.0のドキュメントを参照した場合に、ページトップにABCI 3.0ガイドを参照するようアナウンスを表示する修正も加えています。 こちら文言について修正があればご指摘ください。

<img width="874" alt="3.0ガイドへのアナウンス" src="https://github.com/user-attachments/assets/f43fce3e-84c3-45f8-8876-1b41c2da9a36" />
