### PR TITLE
Redirect to ABCI 3.0 Portal Guide.

### DIFF
--- a/portal/en/overrides/main.html
+++ b/portal/en/overrides/main.html
@@ -3,3 +3,9 @@
 {% block extrahead %}
   <script defer data-domain="docs.abci.ai" src="https://analytics.abci.ai/js/plausible.js"></script>
 {% endblock %}
+
+{% block announce %}
+<p>This document is for ABCI 2.0 and may differ from the current version.
+For the latest documentation, please see <a href="https://docs.abci.ai/v3/portal/en/">ABCI 3.0 Portal Guide</a>.
+</p>
+{% endblock %}

--- a/portal/ja/overrides/main.html
+++ b/portal/ja/overrides/main.html
@@ -3,3 +3,8 @@
 {% block extrahead %}
   <script defer data-domain="docs.abci.ai" src="https://analytics.abci.ai/js/plausible.js"></script>
 {% endblock %}
+
+{% block announce %}
+<p>このドキュメントはABCI 2.0向けの内容であり、現在の仕様とは異なる箇所があります。
+最新のドキュメントは<a href="https://docs.abci.ai/v3/portal/ja/">ABCI 3.0ポータルガイド</a>をご確認ください。</p>
+{% endblock %}

--- a/portal/root/mkdocs.yml
+++ b/portal/root/mkdocs.yml
@@ -12,4 +12,4 @@ theme:
 plugins:
   - redirects:
       redirect_maps:
-        'index.md': 'https://docs.abci.ai/portal/ja/'
+        'index.md': 'https://docs.abci.ai/v3/portal/ja/'


### PR DESCRIPTION
ABCI 2.0ポータルガイドのルート(`https://docs.abci.ai/portal/`)訪問時にABCI 3.0ポータルガイド日本語版(`https://docs.abci.ai/v3/portal/ja/`)へリダイレクトする修正Pull Requestです。

また、ABCI 2.0のドキュメントを参照した場合に、ページトップにABCI 3.0ポータルガイドを参照するようアナウンスを表示する修正も加えています。 こちら文言について修正があればご指摘ください。

<img width="857" alt="20250507-portal-guide-announce" src="https://github.com/user-attachments/assets/e5ff9eae-e638-4230-a2cb-29f2f486ef69" />
